### PR TITLE
Updating docker to point to redis-stack-server

### DIFF
--- a/docs/development/redis-app.md
+++ b/docs/development/redis-app.md
@@ -55,7 +55,7 @@ yarn build
 
     Docker-compose file for Development includes:
 
-    - Service `redis` using [Redismod](https://hub.docker.com/r/redislabs/redismod)
+    - Service `redis` using [Redis Stack](https://hub.docker.com/r/redis/redis-stack-server)
     - Service `grafana` using [Grafana](https://hub.docker.com/r/grafana/grafana) which allow loading unsigned plugins `redis-app` and `redis-datasource`
 
     !!! summary "Redis Data Source"

--- a/includes/redis-app/docker-dev.md
+++ b/includes/redis-app/docker-dev.md
@@ -3,8 +3,8 @@ version: "3.4"
 
 services:
   redis:
-    container_name: redismod
-    image: redislabs/redismod:latest
+    container_name: redis-stack
+    image: redis/redis-stack-server:latest
     ports:
       - 6379:6379/tcp
     # Uncomment and edit the local path in the following line to have


### PR DESCRIPTION
The redis-stack-server docker is now the prefered way for trying out the latest version. This PR attempts to address the locations accordingly, and point to this docker.